### PR TITLE
Linking containers broken

### DIFF
--- a/bin/octo
+++ b/bin/octo
@@ -324,10 +324,8 @@ case "$1" in
       if [ -n "$LINK_NAME" ]
       then
         LINK_NAME="$LINK_NAME:$SOURCE"
-        echo "Linking to: $LINK_NAME"
       else
         LINK_NAME="${BASE}_${SOURCE}:${SOURCE}"
-        echo "Linking to: $LINK_NAME"
       fi
 
       RUN_OPTIONS="$RUN_OPTIONS -link $LINK_NAME"


### PR DESCRIPTION
This is the error I receive when I try to link a container to an existing one:

```
remote: 2014/11/08 17:24:24 Invalid repository name (Linking), only [a-z0-9-_.] are allowed
......
remote: #################################################
remote: Something went wrong, trying again.
remote: Killing the container we just launched.
```

The error seems originated by the `echo` in `/usr/bin/octo`: the String echoed arrive in the variable `RUN_OPTIONS` in [`/home/git/receiver`](https://github.com/octohost/octohost/blob/master/bin/receiver.sh#L44)

Removing the two echo fixed the problem in my octohost.
