### PR TITLE
-name has been replaced by --name

### DIFF
--- a/bin/octo
+++ b/bin/octo
@@ -264,7 +264,7 @@ case "$1" in
       ADD_NAME=$(grep -i "^# ADD_NAME" $DOCKERFILE)
       if [ -n "$ADD_NAME" ]
       then
-        RUN_OPTIONS="$RUN_OPTIONS -name $BASE"
+        RUN_OPTIONS="$RUN_OPTIONS --name $BASE"
       fi
 
       VOLUMES_FROM=$(grep -i "^# VOLUMES_FROM" $DOCKERFILE)


### PR DESCRIPTION
You get a deprecation warning if you use `#ADD_NAME` atm

```
Warning: '-name' is deprecated, it will be replaced by '--name' soon. See usage.
```

See: https://docs.docker.com/reference/run/#name-name