### PR TITLE
privileged added to run options if # PRIVILEGED is seen in Dockerfile

### DIFF
--- a/bin/octo
+++ b/bin/octo
@@ -317,6 +317,11 @@ case "$1" in
       fi
       done < <(grep -i '^# MOUNT_FROM_HOST' $DOCKERFILE )
 
+      PRIVILEGED=$(grep -i "^# PRIVILEGED" $DOCKERFILE)
+      if [ -n "$PRIVILEGED" ]
+      then
+        RUN_OPTIONS="$RUN_OPTIONS --privileged "
+      fi
 
       while read -r PORTS_FROM_HOST ; do
       if [ -n "$PORTS_FROM_HOST" ]


### PR DESCRIPTION
I needed the privileged option so I could shoehorn rancher into octohost:
http://rancher.com/

server:
https://github.com/joshuacox/OctoRancherServer
agent:
https://github.com/joshuacox/OctoRancherAgent

I know we were talking about adding in some GUIs awhile back with @derek-adair just toying around with this new one.  I got it running first using an ansible playbook, then modified octo to do it itself with this PR  playbook here:
https://github.com/joshuacox/rancheros-playbook

you only have to run the server once somewhere and then can connect the agents on as many octohosts (or any generic docker host) as you like.
